### PR TITLE
Add watchexec to poetry run order group.

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -148,6 +148,11 @@ api = "0.6"
     version = "3.2.2"
 
   [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    optional = true
+    version = "2.4.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/cpython"
     version = "0.10.0"
 

--- a/integration/poetry_run_test.go
+++ b/integration/poetry_run_test.go
@@ -63,6 +63,7 @@ func testPoetryRun(t *testing.T, context spec.G, it spec.S) {
 				WithEnv(map[string]string{
 					"BPE_SOME_VARIABLE":      "some-value",
 					"BP_IMAGE_LABELS":        "some-label=some-value",
+					"BP_LIVE_RELOAD_ENABLED": "true",
 				}).
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String())
@@ -94,9 +95,10 @@ func testPoetryRun(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(ContainSubstring("Poetry Run Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Environment Variables Buildpack")))
 			Expect(logs).To(ContainLines(ContainSubstring("Image Labels Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Watchexec Buildpack")))
 
-			Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
-			Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+			Expect(image.Buildpacks[7].Key).To(Equal("paketo-buildpacks/environment-variables"))
+			Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 			Expect(image.Labels["some-label"]).To(Equal("some-value"))
 		})
 	})


### PR DESCRIPTION
## Summary

Add `watchexec` to `poetry-run` order group, and the associated integration test.

Closes #466 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
