### PR TITLE
Remove buildpack.yml from integration test fixtures.

### DIFF
--- a/integration/testdata/ca_cert_apps/pip/buildpack.yml
+++ b/integration/testdata/ca_cert_apps/pip/buildpack.yml
@@ -1,2 +1,0 @@
-python:
-  version: 3.8.X

--- a/integration/testdata/pip/buildpack.yml
+++ b/integration/testdata/pip/buildpack.yml
@@ -1,2 +1,0 @@
-python:
-  version: 3.8.X


### PR DESCRIPTION
## Summary

In preparation for dropping support for `buildpack.yml` (see #478 which bumps the buildpacks that drop support for it) we must remove the `buildpack.yml` files from the integration test fixtures. 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
