### PR TITLE
Remove bionic and add noble builder in integration.json

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -1,6 +1,6 @@
 {
   "builders": [
-    "index.docker.io/paketobuildpacks/builder:buildpackless-base",
-    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest"
+    "index.docker.io/paketobuildpacks/builder-jammy-buildpackless-base:latest",
+    "index.docker.io/paketobuildpacks/ubuntu-noble-builder:latest"
   ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This change removes the ubuntu bionic builder from integration.json. That builder is no longer being updated and the repo is archived. It is also pinned to a version of the lifecycle, [0.16.4](https://github.com/paketo-buildpacks/buildpackless-base-builder/blob/6d4c9cb8f666f27be48d069ed683b800d3fa8ae7/builder.toml#L4), which is incompatible with the image-labels buildpack and is causing the following errors in integration tests.

```
ERROR: failed to build: validating buildpacks: buildpack 'paketo-buildpacks/image-labels@4.10.1' (Buildpack API 0.10) is incompatible with lifecycle '0.16.4' (Buildpack API(s) 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
```

This change also adds the ubuntu noble buildpackless builder to integration.json so we continue to test on multiple version of ubuntu. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
